### PR TITLE
Rename module to github.com/poseidon/terraform-provider-ct

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,23 +4,23 @@ Notable changes between releases.
 
 ## Latest
 
-* Add compatibility with Terraform v0.12. Retain v0.11 compatibility ([#37](https://github.com/coreos/terraform-provider-ct/pull/37))
+* Add compatibility with Terraform v0.12. Retain v0.11 compatibility ([#37](https://github.com/poseidon/terraform-provider-ct/pull/37))
 
 ## v0.3.1
 
-* Document usage with the Terraform [3rd-party plugin](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins) directory ([#35](https://github.com/coreos/terraform-provider-ct/pull/35))
+* Document usage with the Terraform [3rd-party plugin](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins) directory ([#35](https://github.com/poseidon/terraform-provider-ct/pull/35))
 * Provide pre-compiled binaries from Go v1.11.5
   * Add windows release binaries
 
 ## v0.3.0
 
 * Render Ignition Configs at Ingition v2.2.0
-* Add `snippets` field for appending Container Linux Configs to `content` ([#22](https://github.com/coreos/terraform-provider-ct/pull/22))
+* Add `snippets` field for appending Container Linux Configs to `content` ([#22](https://github.com/poseidon/terraform-provider-ct/pull/22))
 * Update `ct` to v0.8.0
 
 ## v0.2.1
 
-* Add `snippets` field for appending Container Linux Configs to `content` ([#22](https://github.com/coreos/terraform-provider-ct/pull/22))
+* Add `snippets` field for appending Container Linux Configs to `content` ([#22](https://github.com/poseidon/terraform-provider-ct/pull/22))
 
 ## v0.2.0
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: build test vet lint fmt
 build: clean bin/terraform-provider-ct
 
 bin/terraform-provider-ct:
-	@go build -o $@ github.com/coreos/terraform-provider-ct
+	@go build -o $@ github.com/poseidon/terraform-provider-ct
 
 .PHONY: test
 test:
@@ -61,4 +61,4 @@ _output/linux-amd64/terraform-provider-ct: GOARGS = GOOS=linux GOARCH=amd64
 _output/darwin-amd64/terraform-provider-ct: GOARGS = GOOS=darwin GOARCH=amd64
 _output/windows-amd64/terraform-provider-ct: GOARGS = GOOS=windows GOARCH=amd64
 _output/%/terraform-provider-ct:
-	$(GOARGS) go build -o $@ github.com/coreos/terraform-provider-ct
+	$(GOARGS) go build -o $@ github.com/poseidon/terraform-provider-ct

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the `terraform-provider-ct` plugin binary for your system to the Terraform 3
 
 ```sh
 VERSION=v0.3.1
-wget https://github.com/coreos/terraform-provider-ct/releases/download/$VERSION/terraform-provider-ct-$VERSION-linux-amd64.tar.gz
+wget https://github.com/poseidon/terraform-provider-ct/releases/download/$VERSION/terraform-provider-ct-$VERSION-linux-amd64.tar.gz
 tar xzf terraform-provider-ct-$VERSION-linux-amd64.tar.gz
 mv terraform-provider-ct-$VERSION-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_$VERSION
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/coreos/terraform-provider-ct
+module github.com/poseidon/terraform-provider-ct
 
 require (
 	github.com/ajeddeloh/go-json v0.0.0-20160803184958-73d058cf8437 // indirect

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/hashicorp/terraform/plugin"
 
-	"github.com/coreos/terraform-provider-ct/ct"
+	"github.com/poseidon/terraform-provider-ct/ct"
 )
 
 func main() {


### PR DESCRIPTION
* Change the module name to reflect the new repo location
* Update README and CHANGES with the new repo location