### PR TITLE
Add .travis.yml test coverage for Go v1.12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 go:
   - "1.10.x"
   - "1.11.x"
+  - "1.12.x"
 install:
   - go get golang.org/x/lint/golint
 script:


### PR DESCRIPTION
* Test the latest 3 versions of Go for consistency across projects