### PR TITLE
Gracefully handle empty snippets

### DIFF
--- a/ct/datasource_ct_config.go
+++ b/ct/datasource_ct_config.go
@@ -80,8 +80,10 @@ func renderConfig(d *schema.ResourceData) (string, error) {
 	strict := d.Get("strict").(bool)
 
 	snippets := make([]string, len(snippetsIface))
-	for i := range snippetsIface {
-		snippets[i] = snippetsIface[i].(string)
+	for i, v := range snippetsIface {
+		if v != nil {
+			snippets[i] = v.(string)
+		}
 	}
 
 	// Fedora CoreOS Config

--- a/ct/datasource_ct_config_test.go
+++ b/ct/datasource_ct_config_test.go
@@ -307,6 +307,31 @@ data "ct_config" "container-linux-strict" {
 }
 `
 
+const emptySnippet = `
+data "ct_config" "empty-snippet" {
+	content = ""
+
+	pretty_print = true
+
+	snippets = [""]
+}
+`
+
+const emptySnippetExpected = `{
+  "ignition": {
+    "config": {},
+    "security": {
+      "tls": {}
+    },
+    "timeouts": {},
+    "version": "2.2.0"
+  },
+  "networkd": {},
+  "passwd": {},
+  "storage": {},
+  "systemd": {}
+}`
+
 func TestRender(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
@@ -339,6 +364,12 @@ func TestRender(t *testing.T) {
 				Config: fedoraCoreOSWithSnippets,
 				Check: r.ComposeTestCheckFunc(
 					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", fedoraCoreOSWithSnippetsExpected),
+				),
+			},
+			r.TestStep{
+				Config: emptySnippet,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.empty-snippet", "rendered", emptySnippetExpected),
 				),
 			},
 		},


### PR DESCRIPTION
If snippet in Terraform code is optional, for example when ternary
operator is used, then provider is not able to handle at the moment and
crashes, trying to cast 'nil' interface into string.

This commit changes the logic to prevent that and makes that only non
'nil' snippets will be used.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>