### PR TITLE
Update release notes for v0.5.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Notable changes between releases.
 
 ## Latest
 
+## v0.5.1
+
+* Allow empty string snippets ([#61](https://github.com/poseidon/terraform-provider-ct/pull/61))
+
 ## v0.5.0
 
 * Add support for Fedora CoreOS `snippets` ([#58](https://github.com/poseidon/terraform-provider-ct/pull/58))


### PR DESCRIPTION
* Add release note for [#61](https://github.com/poseidon/terraform-provider-ct/pull/61)
* Likely the last release with Container Linux Config Ignition v2.2 spec, https://github.com/poseidon/terraform-provider-ct/pull/60 uses v2.3 spec