### PR TITLE
Fix empty "rendered" with FCC 1.1 and snippets

### DIFF
--- a/ct/datasource_ct_config.go
+++ b/ct/datasource_ct_config.go
@@ -149,7 +149,7 @@ func mergeFCCSnippets(ignBytes []byte, pretty, strict bool, snippets []string) (
 		if pretty {
 			return json.MarshalIndent(ign31, "", "  ")
 		}
-		return json.Marshal(ign)
+		return json.Marshal(ign31)
 	}
 
 	var ign30 ignition30Types.Config

--- a/ct/datasource_ct_config.go
+++ b/ct/datasource_ct_config.go
@@ -133,10 +133,7 @@ func mergeFCCSnippets(ignBytes []byte, pretty, strict bool, snippets []string) (
 		if err != nil {
 			return nil, fmt.Errorf("FCC v1.2.0 merge error: %v", err)
 		}
-		if pretty {
-			return json.MarshalIndent(ign, "", "  ")
-		}
-		return json.Marshal(ign)
+		return marshalJSON(ign, pretty)
 	}
 
 	ign31, _, err := ignition31.Parse(ignBytes)
@@ -146,10 +143,7 @@ func mergeFCCSnippets(ignBytes []byte, pretty, strict bool, snippets []string) (
 		if err != nil {
 			return nil, fmt.Errorf("FCC v1.1.0 merge error: %v", err)
 		}
-		if pretty {
-			return json.MarshalIndent(ign31, "", "  ")
-		}
-		return json.Marshal(ign31)
+		return marshalJSON(ign31, pretty)
 	}
 
 	var ign30 ignition30Types.Config
@@ -162,10 +156,7 @@ func mergeFCCSnippets(ignBytes []byte, pretty, strict bool, snippets []string) (
 	if err != nil {
 		return nil, fmt.Errorf("FCC v1.0.0 merge error: %v", err)
 	}
-	if pretty {
-		return json.MarshalIndent(ign30, "", "  ")
-	}
-	return json.Marshal(ign30)
+	return marshalJSON(ign30, pretty)
 }
 
 // merge FCC v1.2.0 snippets
@@ -252,10 +243,7 @@ func renderCLC(data []byte, platform string, pretty, strict bool, snippets []str
 		ign = ignition.Append(ign, ignext)
 	}
 
-	if pretty {
-		return json.MarshalIndent(ign, "", "  ")
-	}
-	return json.Marshal(ign)
+	return marshalJSON(ign, pretty)
 }
 
 // Parse Container Linux config and convert to Ignition v2.2.0 format.
@@ -276,4 +264,11 @@ func clcToIgnition(data []byte, platform string, strict bool) (ignitionTypes.Con
 		return ignitionTypes.Config{}, fmt.Errorf("error converting to Ignition: %v", report.String())
 	}
 	return ign, nil
+}
+
+func marshalJSON(v interface{}, pretty bool) ([]byte, error) {
+	if pretty {
+		return json.MarshalIndent(v, "", "  ")
+	}
+	return json.Marshal(v)
 }

--- a/ct/datasource_ct_config_test.go
+++ b/ct/datasource_ct_config_test.go
@@ -191,6 +191,31 @@ const containerLinuxSnippetsExpected = `{
   }
 }`
 
+const containerLinuxSnippetsPrettyFalseResource = `
+data "ct_config" "container-linux-snippets" {
+	pretty_print = false
+	content = <<EOT
+---
+storage:
+  filesystems:
+    - name: "rootfs"
+      mount:
+        device: "/dev/disk/by-label/ROOT"
+        format: "ext4"
+EOT
+	snippets = [
+<<EOT
+---
+systemd:
+  units:
+    - name: docker.service
+      enable: true
+EOT
+	]
+}
+`
+const containerLinuxSnippetsPrettyFalseExpected = `{"ignition":{"config":{},"security":{"tls":{}},"timeouts":{},"version":"2.3.0"},"networkd":{},"passwd":{},"storage":{"filesystems":[{"mount":{"device":"/dev/disk/by-label/ROOT","format":"ext4"},"name":"rootfs"}]},"systemd":{"units":[{"enable":true,"name":"docker.service"}]}}`
+
 func TestContainerLinuxConfig(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
@@ -211,6 +236,12 @@ func TestContainerLinuxConfig(t *testing.T) {
 				Config: containerLinuxSnippetsResource,
 				Check: r.ComposeTestCheckFunc(
 					r.TestCheckResourceAttr("data.ct_config.container-linux-snippets", "rendered", containerLinuxSnippetsExpected),
+				),
+			},
+			r.TestStep{
+				Config: containerLinuxSnippetsPrettyFalseResource,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.container-linux-snippets", "rendered", containerLinuxSnippetsPrettyFalseExpected),
 				),
 			},
 		},
@@ -327,6 +358,36 @@ const fedoraCoreOSV12WithSnippetsExpected = `{
   }
 }`
 
+const fedoraCoreOSV12WithSnippetsPrettyFalse = `
+data "ct_config" "fedora-coreos-snippets" {
+  pretty_print = false
+  strict = true
+  content = <<EOT
+---
+variant: fcos
+version: 1.2.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - key
+EOT
+	snippets = [
+<<EOT
+---
+variant: fcos
+version: 1.2.0
+systemd:
+  units:
+    - name: docker.service
+      enabled: true
+EOT
+	]
+}
+`
+
+const fedoraCoreOSV12WithSnippetsPrettyFalseExpected = `{"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{},"version":"3.2.0"},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["key"]}]},"storage":{},"systemd":{"units":[{"enabled":true,"name":"docker.service"}]}}`
+
 func TestFedoraCoreOSConfigV12(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
@@ -341,6 +402,12 @@ func TestFedoraCoreOSConfigV12(t *testing.T) {
 				Config: fedoraCoreOSV12WithSnippets,
 				Check: r.ComposeTestCheckFunc(
 					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", fedoraCoreOSV12WithSnippetsExpected),
+				),
+			},
+			r.TestStep{
+				Config: fedoraCoreOSV12WithSnippetsPrettyFalse,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", fedoraCoreOSV12WithSnippetsPrettyFalseExpected),
 				),
 			},
 		},
@@ -443,6 +510,36 @@ const fedoraCoreOSV11WithSnippetsExpected = `{
   }
 }`
 
+const fedoraCoreOSV11WithSnippetsPrettyFalse = `
+data "ct_config" "fedora-coreos-snippets" {
+  pretty_print = false
+  strict = true
+  content = <<EOT
+---
+variant: fcos
+version: 1.1.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - key
+EOT
+	snippets = [
+<<EOT
+---
+variant: fcos
+version: 1.1.0
+systemd:
+  units:
+    - name: docker.service
+      enabled: true
+EOT
+	]
+}
+`
+
+const fedoraCoreOSV11WithSnippetsPrettyFalseExpected = `{"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{},"version":"3.1.0"},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["key"]}]},"storage":{},"systemd":{"units":[{"enabled":true,"name":"docker.service"}]}}`
+
 func TestFedoraCoreOSConfigV11(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
@@ -457,6 +554,12 @@ func TestFedoraCoreOSConfigV11(t *testing.T) {
 				Config: fedoraCoreOSV11WithSnippets,
 				Check: r.ComposeTestCheckFunc(
 					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", fedoraCoreOSV11WithSnippetsExpected),
+				),
+			},
+			r.TestStep{
+				Config: fedoraCoreOSV11WithSnippetsPrettyFalse,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", fedoraCoreOSV11WithSnippetsPrettyFalseExpected),
 				),
 			},
 		},
@@ -559,6 +662,36 @@ const fedoraCoreOSV10WithSnippetsExpected = `{
   }
 }`
 
+const fedoraCoreOSV10WithSnippetsPrettyFalse = `
+data "ct_config" "fedora-coreos-snippets" {
+  pretty_print = false
+  strict = true
+  content = <<EOT
+---
+variant: fcos
+version: 1.0.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - key
+EOT
+	snippets = [
+<<EOT
+---
+variant: fcos
+version: 1.0.0
+systemd:
+  units:
+    - name: docker.service
+      enabled: true
+EOT
+	]
+}
+`
+
+const fedoraCoreOSV10WithSnippetsPrettyFalseExpected = `{"ignition":{"config":{"replace":{"source":null,"verification":{}}},"security":{"tls":{}},"timeouts":{},"version":"3.0.0"},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["key"]}]},"storage":{},"systemd":{"units":[{"enabled":true,"name":"docker.service"}]}}`
+
 func TestFedoraCoreOSConfigV10(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
@@ -573,6 +706,12 @@ func TestFedoraCoreOSConfigV10(t *testing.T) {
 				Config: fedoraCoreOSV10WithSnippets,
 				Check: r.ComposeTestCheckFunc(
 					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", fedoraCoreOSV10WithSnippetsExpected),
+				),
+			},
+			r.TestStep{
+				Config: fedoraCoreOSV10WithSnippetsPrettyFalse,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", fedoraCoreOSV10WithSnippetsPrettyFalseExpected),
 				),
 			},
 		},


### PR DESCRIPTION
When `pretty_print = false` is used along with FCC 1.1 configuration _and_ snippets, the result is an empty (default) Ignition document. Adapting a case from the tests:

```tf
terraform {
  required_version = ">= 0.13"

  required_providers {
    ct = {
      source  = "poseidon/ct"
      version = "~> 0.7.0"
    }
  }
}

data "ct_config" "fedora-coreos-snippets" {
  pretty_print = false
  strict = true
  content = <<EOT
---
variant: fcos
version: 1.1.0
passwd:
  users:
    - name: core
      ssh_authorized_keys:
        - key
EOT
	snippets = [
<<EOT
---
variant: fcos
version: 1.1.0
systemd:
  units:
    - name: docker.service
      enabled: true
EOT
	]
}

output "ignition" {
  value = data.ct_config.fedora-coreos-snippets.rendered
}
```

The result is:

```
$ terraform apply -auto-approve
data.ct_config.fedora-coreos-snippets: Refreshing state... [id=475385134]

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

ignition = {"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{}},"passwd":{},"storage":{},"systemd":{}}
```

This is a regression from 0.6, which outputs the expected rendered result:

```
$ terraform apply -auto-approve
data.ct_config.fedora-coreos-snippets: Refreshing state... [id=475385134]

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

ignition = {"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{},"version":"3.1.0"},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["key"]}]},"storage":{},"systemd":{"units":[{"enabled":true,"name":"docker.service"}]}}
```

I added test cases where `pretty_print` is set to false, which demonstrated that this is only an issue with FCC version 1.1. The cause turns out to be the wrong Ignition object being passed to `json.MarshalIndent`, specifically `ign` instead of `ign31`. Passing that in to match `json.Marshal` results in a passing test.