### PR TITLE
Add Fedora CoreOS Config v1.3.0 spec coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Container Linux Configs render a fixed Ignition version, depending on the `terra
 
 | terraform-provider-ct | CLC to Ignition     | FCC to Ignition    |
 |-----------------------|---------------------|--------------------|
+| 0.8.x                 | Renders 2.3.0       | FCC (1.0, 1.1, 1.2, 1.3) -> Ignition (3.0, 3.1, 3.2, 3.2)
 | 0.7.x                 | Renders 2.3.0       | FCC (1.0, 1.1, 1.2) -> Ignition (3.0, 3.1, 3.2) |
 | 0.6.x                 | Renders 2.3.0       | FCC 1.0.0 -> Ignition 3.0.0, FCC 1.1.0 -> Ignition v3.1.0 |
 | 0.5.x                 | Renders 2.2.0       | FCC 1.0.0 -> Ignition 3.0.0 |

--- a/ct/datasource_ct_config_test.go
+++ b/ct/datasource_ct_config_test.go
@@ -250,6 +250,170 @@ func TestContainerLinuxConfig(t *testing.T) {
 
 // Fedora CoreOS
 
+const fedoraCoreOSV13Resource = `
+data "ct_config" "fedora-coreos" {
+  pretty_print = true
+  strict = true
+  content = <<EOT
+---
+variant: fcos
+version: 1.3.0
+storage:
+  luks:
+    - name: data
+      device: /dev/vdb
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - key
+EOT
+}
+`
+
+const fedoraCoreOSV13Expected = `{
+  "ignition": {
+    "version": "3.2.0"
+  },
+  "passwd": {
+    "users": [
+      {
+        "name": "core",
+        "sshAuthorizedKeys": [
+          "key"
+        ]
+      }
+    ]
+  },
+  "storage": {
+    "luks": [
+      {
+        "device": "/dev/vdb",
+        "name": "data"
+      }
+    ]
+  }
+}`
+
+const fedoraCoreOSV13WithSnippets = `
+data "ct_config" "fedora-coreos-snippets" {
+  pretty_print = true
+  strict = true
+  content = <<EOT
+---
+variant: fcos
+version: 1.3.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - key
+EOT
+	snippets = [
+<<EOT
+---
+variant: fcos
+version: 1.3.0
+systemd:
+  units:
+    - name: docker.service
+      enabled: true
+EOT
+	]
+}
+`
+
+const fedoraCoreOSV13WithSnippetsExpected = `{
+  "ignition": {
+    "config": {
+      "replace": {
+        "verification": {}
+      }
+    },
+    "proxy": {},
+    "security": {
+      "tls": {}
+    },
+    "timeouts": {},
+    "version": "3.2.0"
+  },
+  "passwd": {
+    "users": [
+      {
+        "name": "core",
+        "sshAuthorizedKeys": [
+          "key"
+        ]
+      }
+    ]
+  },
+  "storage": {},
+  "systemd": {
+    "units": [
+      {
+        "enabled": true,
+        "name": "docker.service"
+      }
+    ]
+  }
+}`
+
+const fedoraCoreOSV13WithSnippetsPrettyFalse = `
+data "ct_config" "fedora-coreos-snippets" {
+  pretty_print = false
+  strict = true
+  content = <<EOT
+---
+variant: fcos
+version: 1.3.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - key
+EOT
+	snippets = [
+<<EOT
+---
+variant: fcos
+version: 1.3.0
+systemd:
+  units:
+    - name: docker.service
+      enabled: true
+EOT
+	]
+}
+`
+
+const fedoraCoreOSV13WithSnippetsPrettyFalseExpected = `{"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{},"version":"3.2.0"},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["key"]}]},"storage":{},"systemd":{"units":[{"enabled":true,"name":"docker.service"}]}}`
+
+func TestFedoraCoreOSConfigV13(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		Providers: testProviders,
+		Steps: []r.TestStep{
+			r.TestStep{
+				Config: fedoraCoreOSV13Resource,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos", "rendered", fedoraCoreOSV13Expected),
+				),
+			},
+			r.TestStep{
+				Config: fedoraCoreOSV13WithSnippets,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", fedoraCoreOSV13WithSnippetsExpected),
+				),
+			},
+			r.TestStep{
+				Config: fedoraCoreOSV13WithSnippetsPrettyFalse,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", fedoraCoreOSV13WithSnippetsPrettyFalseExpected),
+				),
+			},
+		},
+	})
+}
+
 const fedoraCoreOSV12Resource = `
 data "ct_config" "fedora-coreos" {
   pretty_print = true


### PR DESCRIPTION
* Fedora CoreOS Config v1.3.0 transpiles to Ignition v3.2.0, just like FCC v1.2.0 (notice)