### PR TITLE
Update examples from ct v0.7.1 to v0.8.0

### DIFF
--- a/examples/content/fcc-snippet.yaml
+++ b/examples/content/fcc-snippet.yaml
@@ -1,5 +1,5 @@
 variant: fcos
-version: 1.2.0
+version: 1.3.0
 storage:
   files:
     - path: /etc/zincati/config.d/90-disable-feature.toml

--- a/examples/content/fcc.yaml
+++ b/examples/content/fcc.yaml
@@ -1,6 +1,6 @@
 ---
 variant: fcos
-version: 1.2.0
+version: 1.3.0
 storage:
   filesystems:
     - path: /

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
   required_providers {
     local    = "~> 1.2"
     template = "~> 2.1"


### PR DESCRIPTION
* Allow using Terraform v0.13 or v0.14 in example
* Show using the Fedora CoreOS Config version v1.3.0.

Note that FCC v1.3.0 (like v1.2.0) renders to Ignition 3.2.0 (no change)