### PR TITLE
Remove tarball release archive format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,21 +47,10 @@ clean:
 .PHONY: release
 release: \
 	clean \
-	_output/plugin-linux-amd64.tar.gz \
-	_output/plugin-linux-arm64.tar.gz \
-	_output/plugin-darwin-amd64.tar.gz \
-	_output/plugin-windows-amd64.tar.gz \
 	_output/plugin-linux-amd64.zip \
 	_output/plugin-linux-arm64.zip \
 	_output/plugin-darwin-amd64.zip \
 	_output/plugin-windows-amd64.zip
-
-_output/plugin-%.tar.gz: NAME=terraform-provider-ct-$(VERSION)-$*
-_output/plugin-%.tar.gz: DEST=_output/$(NAME)
-_output/plugin-%.tar.gz: _output/%/terraform-provider-ct
-	@mkdir -p $(DEST)
-	@cp _output/$*/terraform-provider-ct $(DEST)
-	@tar zcvf $(DEST).tar.gz -C _output $(NAME)
 
 _output/plugin-%.zip: NAME=terraform-provider-ct_$(SEMVER)_$(subst -,_,$*)
 _output/plugin-%.zip: DEST=_output/$(NAME)
@@ -79,18 +68,10 @@ _output/%/terraform-provider-ct:
 
 release-sign:
 	cd _output; sha256sum *.zip > terraform-provider-ct_$(SEMVER)_SHA256SUMS
-	gpg2 --armor --detach-sign _output/terraform-provider-ct-$(VERSION)-linux-amd64.tar.gz
-	gpg2 --armor --detach-sign _output/terraform-provider-ct-$(VERSION)-linux-arm64.tar.gz
-	gpg2 --armor --detach-sign _output/terraform-provider-ct-$(VERSION)-darwin-amd64.tar.gz
-	gpg2 --armor --detach-sign _output/terraform-provider-ct-$(VERSION)-windows-amd64.tar.gz
 	gpg2 --detach-sign _output/terraform-provider-ct_$(SEMVER)_SHA256SUMS
 
 release-verify: NAME=_output/terraform-provider-ct
 release-verify:
-	gpg2 --verify $(NAME)-$(VERSION)-linux-amd64.tar.gz.asc $(NAME)-$(VERSION)-linux-amd64.tar.gz
-	gpg2 --verify $(NAME)-$(VERSION)-linux-arm64.tar.gz.asc $(NAME)-$(VERSION)-linux-arm64.tar.gz
-	gpg2 --verify $(NAME)-$(VERSION)-darwin-amd64.tar.gz.asc $(NAME)-$(VERSION)-darwin-amd64.tar.gz
-	gpg2 --verify $(NAME)-$(VERSION)-windows-amd64.tar.gz.asc $(NAME)-$(VERSION)-windows-amd64.tar.gz
 	gpg2 --verify $(NAME)_$(SEMVER)_SHA256SUMS.sig $(NAME)_$(SEMVER)_SHA256SUMS
 
 


### PR DESCRIPTION
* Originally, Terraform Providers were packaged in tarball archives like any typical Go binary release. In Terraform
today, provider plugins are fetched from the Terraform Registry, which uses a zip file format for ingestion
* Consolidate to just using the zip format for releases, it contains the same binaries compiled for OSes/archs

Rel: https://registry.terraform.io/providers/poseidon/ct/latest