### PR TITLE
Rename github.com/coreos/fcct to github.com/coreos/butane

### DIFF
--- a/ct/datasource_ct_config.go
+++ b/ct/datasource_ct_config.go
@@ -10,9 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	butane "github.com/coreos/butane/config"
+	"github.com/coreos/butane/config/common"
 	clct "github.com/coreos/container-linux-config-transpiler/config"
-	fcct "github.com/coreos/fcct/config"
-	"github.com/coreos/fcct/config/common"
 
 	ignition "github.com/coreos/ignition/config/v2_3"
 	ignitionTypes "github.com/coreos/ignition/config/v2_3/types"
@@ -106,7 +106,7 @@ func renderConfig(d *schema.ResourceData) (string, error) {
 
 // Translate Fedora CoreOS config to Ignition v3.X.Y
 func fccToIgnition(data []byte, pretty, strict bool, snippets []string) ([]byte, error) {
-	ignBytes, _, err := fcct.TranslateBytes(data, common.TranslateBytesOptions{
+	ignBytes, _, err := butane.TranslateBytes(data, common.TranslateBytesOptions{
 		Pretty: pretty,
 		Strict: strict,
 	})
@@ -127,7 +127,7 @@ func fccToIgnition(data []byte, pretty, strict bool, snippets []string) ([]byte,
 // versions. Then translate and parse FCC snippets as the chosen Ignition
 // version to merge.
 // version
-// Upstream might later handle: https://github.com/coreos/fcct/issues/118
+// Upstream might later handle: https://github.com/coreos/butane/issues/118
 // Note: This means snippets version must match the main config version.
 func mergeFCCSnippets(ignBytes []byte, pretty, strict bool, snippets []string) ([]byte, error) {
 	ign, _, err := ignition32.Parse(ignBytes)
@@ -166,7 +166,7 @@ func mergeFCCSnippets(ignBytes []byte, pretty, strict bool, snippets []string) (
 // merge FCC v1.2.0 snippets
 func mergeFCC12(ign ignition32Types.Config, snippets []string, pretty, strict bool) (ignition32Types.Config, error) {
 	for _, snippet := range snippets {
-		ignextBytes, _, err := fcct.TranslateBytes([]byte(snippet), common.TranslateBytesOptions{
+		ignextBytes, _, err := butane.TranslateBytes([]byte(snippet), common.TranslateBytesOptions{
 			Pretty: pretty,
 			Strict: strict,
 		})
@@ -189,7 +189,7 @@ func mergeFCC12(ign ignition32Types.Config, snippets []string, pretty, strict bo
 // merge FCC v1.1.0 snippets
 func mergeFCC11(ign ignition31Types.Config, snippets []string, pretty, strict bool) (ignition31Types.Config, error) {
 	for _, snippet := range snippets {
-		ignextBytes, _, err := fcct.TranslateBytes([]byte(snippet), common.TranslateBytesOptions{
+		ignextBytes, _, err := butane.TranslateBytes([]byte(snippet), common.TranslateBytesOptions{
 			Pretty: pretty,
 			Strict: strict,
 		})
@@ -212,7 +212,7 @@ func mergeFCC11(ign ignition31Types.Config, snippets []string, pretty, strict bo
 // merge FCC v1.0.0 snippets
 func mergeFCCV10(ign ignition30Types.Config, snippets []string, pretty, strict bool) (ignition30Types.Config, error) {
 	for _, snippet := range snippets {
-		ignextBytes, _, err := fcct.TranslateBytes([]byte(snippet), common.TranslateBytesOptions{
+		ignextBytes, _, err := butane.TranslateBytes([]byte(snippet), common.TranslateBytesOptions{
 			Pretty: pretty,
 			Strict: strict,
 		})

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ require (
 	github.com/ajeddeloh/go-json v0.0.0-20170920214419-6a2fe990e083 // indirect
 	github.com/ajeddeloh/yaml v0.0.0-20170912190910-6b94386aeefd // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
+	github.com/coreos/butane v0.11.0
 	github.com/coreos/container-linux-config-transpiler v0.9.1-0.20200402130652-e4d5be564a0b
-	github.com/coreos/fcct v0.10.0
 	github.com/coreos/ignition v0.35.0
-	github.com/coreos/ignition/v2 v2.9.0
+	github.com/coreos/ignition/v2 v2.9.1-0.20210304043908-47da4066daa8
 	github.com/hashicorp/terraform-plugin-sdk v1.17.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.6.1
 	go4.org v0.0.0-20200312051459-7028f7b4a332 // indirect
 )
 
-go 1.13
+go 1.15

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/clarketm/json v1.14.1 h1:43bkbTTKKdDx7crs3WHzkrnH6S1EvAF1VZrdFGMmmz4=
 github.com/clarketm/json v1.14.1/go.mod h1:ynr2LRfb0fQU34l07csRNBTcivjySLLiY1YzQqKVfdo=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/coreos/butane v0.11.0 h1:BmoXR3YPIYlSVaV7AW98Yhr7eVj8/P3xeNn13Tpyr9M=
+github.com/coreos/butane v0.11.0/go.mod h1:FAzykYJ92Wohb81M63qkfi+VKLKS2WW287g8fnvIrWE=
 github.com/coreos/container-linux-config-transpiler v0.9.1-0.20200402130652-e4d5be564a0b h1:ncpb1vSLw4mC2l+3GNEGw2t0V0Gb+mHe0qIYZicwbT0=
 github.com/coreos/container-linux-config-transpiler v0.9.1-0.20200402130652-e4d5be564a0b/go.mod h1:SlcxXZQ2c42knj8pezMiQsM1f+ADxFMjGetuMKR/YSQ=
 github.com/coreos/fcct v0.10.0 h1:or1sVKg39HtM+MU3dXc05BLQZobnMGURrhfgVqxTrMM=
@@ -108,6 +110,8 @@ github.com/coreos/ignition v0.35.0/go.mod h1:WJQapxzEn9DE0ryxsGvm8QnBajm/XsS/Pkr
 github.com/coreos/ignition/v2 v2.8.1/go.mod h1:A5lFFzA2/zvZQPVEvI1lR5WPLWRb7KZ7Q1QOeUMtcAc=
 github.com/coreos/ignition/v2 v2.9.0 h1:Zl5N08OyqlECB8BrBlMDp3Jf1ShwVTtREPcUq/YO034=
 github.com/coreos/ignition/v2 v2.9.0/go.mod h1:A5lFFzA2/zvZQPVEvI1lR5WPLWRb7KZ7Q1QOeUMtcAc=
+github.com/coreos/ignition/v2 v2.9.1-0.20210304043908-47da4066daa8 h1:+EWz7B9m/XyAb/6NQfrwy7vvJ8CwFViiCAHnpZAi9BE=
+github.com/coreos/ignition/v2 v2.9.1-0.20210304043908-47da4066daa8/go.mod h1:A5lFFzA2/zvZQPVEvI1lR5WPLWRb7KZ7Q1QOeUMtcAc=
 github.com/coreos/vcontext v0.0.0-20201120045928-b0e13dab675c h1:jA28WeORitsxGFVWhyWB06sAG2HbLHPQuHwDydhU2CQ=
 github.com/coreos/vcontext v0.0.0-20201120045928-b0e13dab675c/go.mod h1:z4pMVvaUrxs98RROlIYdAQCKhEicjnTirOaVyDRH5h8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
* The upstream `github.com/coreos/fcct` module was renamed to `github.com/coreos/butane`
* Update butane from v0.10.0 to v0.11.0

Rel: https://github.com/coreos/butane/releases/tag/v0.11.0