### PR TITLE
Add Butane Config v1.4.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ passwd:
 # Butane config
 ---
 variant: fcos
-version: 1.3.0
+version: 1.4.0
 passwd:
   users:
     - name: core
@@ -80,6 +80,7 @@ Container Linux Configs render a fixed Ignition version, depending on the `terra
 
 | terraform-provider-ct | CLC to Ignition     | Butane to Ignition    |
 |-----------------------|---------------------|--------------------|
+| 0.9.x                 | Renders 2.3.0       | Butane (1.0, 1.1, 1.2, 1.3, 1.4) -> Ignition (3.0, 3.1, 3.2, 3.2, 3.3)
 | 0.8.x                 | Renders 2.3.0       | Butane (1.0, 1.1, 1.2, 1.3) -> Ignition (3.0, 3.1, 3.2, 3.2)
 | 0.7.x                 | Renders 2.3.0       | Butane (1.0, 1.1, 1.2) -> Ignition (3.0, 3.1, 3.2) |
 | 0.6.x                 | Renders 2.3.0       | Butane (1.0, 1.1) -> Ignition (3.0, 3.1) |

--- a/ct/datasource_ct_config_test.go
+++ b/ct/datasource_ct_config_test.go
@@ -250,6 +250,171 @@ func TestContainerLinuxConfig(t *testing.T) {
 
 // Fedora CoreOS
 
+const fedoraCoreOSV14Resource = `
+data "ct_config" "fedora-coreos" {
+  pretty_print = true
+  strict = true
+  content = <<EOT
+---
+variant: fcos
+version: 1.4.0
+storage:
+  luks:
+    - name: data
+      device: /dev/vdb
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - key
+EOT
+}
+`
+
+const fedoraCoreOSV14Expected = `{
+  "ignition": {
+    "version": "3.3.0"
+  },
+  "passwd": {
+    "users": [
+      {
+        "name": "core",
+        "sshAuthorizedKeys": [
+          "key"
+        ]
+      }
+    ]
+  },
+  "storage": {
+    "luks": [
+      {
+        "device": "/dev/vdb",
+        "name": "data"
+      }
+    ]
+  }
+}`
+
+const fedoraCoreOSV14WithSnippets = `
+data "ct_config" "fedora-coreos-snippets" {
+  pretty_print = true
+  strict = true
+  content = <<EOT
+---
+variant: fcos
+version: 1.4.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - key
+EOT
+	snippets = [
+<<EOT
+---
+variant: fcos
+version: 1.4.0
+systemd:
+  units:
+    - name: docker.service
+      enabled: true
+EOT
+	]
+}
+`
+
+const fedoraCoreOSV14WithSnippetsExpected = `{
+  "ignition": {
+    "config": {
+      "replace": {
+        "verification": {}
+      }
+    },
+    "proxy": {},
+    "security": {
+      "tls": {}
+    },
+    "timeouts": {},
+    "version": "3.3.0"
+  },
+  "kernelArguments": {},
+  "passwd": {
+    "users": [
+      {
+        "name": "core",
+        "sshAuthorizedKeys": [
+          "key"
+        ]
+      }
+    ]
+  },
+  "storage": {},
+  "systemd": {
+    "units": [
+      {
+        "enabled": true,
+        "name": "docker.service"
+      }
+    ]
+  }
+}`
+
+const fedoraCoreOSV14WithSnippetsPrettyFalse = `
+data "ct_config" "fedora-coreos-snippets" {
+  pretty_print = false
+  strict = true
+  content = <<EOT
+---
+variant: fcos
+version: 1.4.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - key
+EOT
+	snippets = [
+<<EOT
+---
+variant: fcos
+version: 1.4.0
+systemd:
+  units:
+    - name: docker.service
+      enabled: true
+EOT
+	]
+}
+`
+
+const fedoraCoreOSV14WithSnippetsPrettyFalseExpected = `{"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{},"version":"3.3.0"},"kernelArguments":{},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["key"]}]},"storage":{},"systemd":{"units":[{"enabled":true,"name":"docker.service"}]}}`
+
+func TestFedoraCoreOSConfigV14(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		Providers: testProviders,
+		Steps: []r.TestStep{
+			r.TestStep{
+				Config: fedoraCoreOSV14Resource,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos", "rendered", fedoraCoreOSV14Expected),
+				),
+			},
+			r.TestStep{
+				Config: fedoraCoreOSV14WithSnippets,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", fedoraCoreOSV14WithSnippetsExpected),
+				),
+			},
+			r.TestStep{
+				Config: fedoraCoreOSV14WithSnippetsPrettyFalse,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", fedoraCoreOSV14WithSnippetsPrettyFalseExpected),
+				),
+			},
+		},
+	})
+}
+
 const fedoraCoreOSV13Resource = `
 data "ct_config" "fedora-coreos" {
   pretty_print = true


### PR DESCRIPTION
* Butane Config (formerly Fedora CoreOS Config) v1.4.0 transpiles to Ignition v3.3.0