### PR TITLE
Add Go v1.18 to test matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,10 +13,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.16', '1.17']
+        go: ['1.17', '1.18']
     steps:
       - name: setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{matrix.go}}
 
@@ -26,10 +26,10 @@ jobs:
           terraform_wrapper: false
 
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: tools
-        run: GO111MODULE=off go get golang.org/x/lint/golint
+        run: go install golang.org/x/lint/golint@latest
 
       - name: test
         run: make

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # config-transpiler Provider
 
-`terraform-provider-ct` allows Terraform to validate a [Container Linux Config](https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/configuration.md) or a [Butane config](https://coreos.github.io/butane/specs/) and transpile it as an [Ignition config](https://coreos.github.io/ignition/) for machine consumption.
+`terraform-provider-ct` allows Terraform to validate a [Butane config](https://coreos.github.io/butane/specs/) or [Container Linux Config](https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/configuration.md) and transpile to an [Ignition config](https://coreos.github.io/ignition/) for machine consumption.
 
 ## Usage
 
@@ -13,17 +13,19 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.9.1"
+      version = "0.10.0"
     }
   }
 }
 ```
 
-Define a Container Linux Config (CLC) or Butane config (for Fedora CoreOS):
+Define a Butane config (for Fedora CoreOS) or Container Linux Config (for Flatcar Linux):
 
 ```yaml
-# Container Linux Config
+# Butane config
 ---
+variant: fcos
+version: 1.4.0
 passwd:
   users:
     - name: core
@@ -32,10 +34,8 @@ passwd:
 ```
 
 ```yaml
-# Butane config
+# Container Linux Config
 ---
-variant: fcos
-version: 1.4.0
 passwd:
   users:
     - name: core


### PR DESCRIPTION
* Update Github Actions `setup-go` and `checkout`
* Change `go get <tool>` to `go install <tool>`
* Remove Go v1.16