### PR TITLE
feat: support files_dir

### DIFF
--- a/docs/data-sources/ct_config.md
+++ b/docs/data-sources/ct_config.md
@@ -26,12 +26,12 @@ See the [Container Linux](examples/container-linux.tf) or [Fedora CoreOS](exampl
 ## Argument Reference
 
 * `content` - contents of a Container Linux Config (CLC) or Fedora CoreOS Config (FCC) that should be validated and transpiled to Ignition.
+* `files_dir` - set path when using `local` as source when including files (default: "").
 * `strict` - strictly treat validation warnings as errors (default: false).
-* `pretty_print` - indent transpiled Ignition for visual prettiness (default: false)
+* `pretty_print` - indent transpiled Ignition for visual prettiness (default: false).
 * `snippets` - list of Container Linux Config (CLC) or Fedora CoreOS Config (FCC) snippets to merge into the content. For FCCs, content and snippet configs must have the same `version`.
-* `platform` - (Container Linux only) - enable [platform-specific](https://github.com/coreos/container-linux-config-transpiler/blob/master/config/platform/platform.go) susbstitutions
+* `platform` - (Container Linux only) - enable [platform-specific](https://github.com/coreos/container-linux-config-transpiler/blob/master/config/platform/platform.go) susbstitutions.
 
 ## Argument Attributes
 
-* `rendered` - transpiled Ignition configuration
-
+* `rendered` - transpiled Ignition configuration.


### PR DESCRIPTION
When using `local` to include files, we need to se a `--files-dir` flag,
this add similar support for the provider.

```yaml
variant: fcos
version: 1.4.0
storage:
  files:
    - path: /tmp/external_file
      contents:
        local: local_file
```

```terraform
data "ct_config" "local_include" {
  content      = file("local_file_with_include.yaml")
  files_dir    = path.module
}
```

---

I assume I would need to add tests.  I'll look more into doing tests if this might be merged.

Ref.: https://github.com/coreos/butane/blob/f27c71d3eb38cf09012b87fd28e6b5767c2d85eb/config/common/common.go#L18