### PR TITLE
Add Butane Config flatcar variant

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,11 +1,6 @@
 name: test
 on:
   push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
 jobs:
   build:
     name: go

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,13 @@ Notable changes between releases.
 
 ## Latest
 
+## v0.11.0
+
+* Update coreos/butane from v0.14.0 to v0.15.0 ([#126](https://github.com/poseidon/terraform-provider-ct/pull/126))
+  * Add `flatcar` Butane Config variant with spec version 1.0.0 (generates Ignition v3.3.0)
+* Deprecate Container Linux Configs (please migrate to Butane Configs)
+* Update Go version to v1.18
+
 ## v0.10.0
 
 * Change how older (< 1.4) Butane Configs are parsed to Ignition ([#116](https://github.com/poseidon/terraform-provider-ct/pull/116))

--- a/README.md
+++ b/README.md
@@ -13,14 +13,13 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.10.0"
+      version = "0.11.0"
     }
   }
 }
 ```
 
-
-Define a Butane config (for Fedora CoreOS) or Container Linux Config (for Flatcar Linux):
+Define a Butane config for Fedora CoreOS or Flatcar Linux:
 
 ```yaml
 # Butane config
@@ -33,6 +32,20 @@ passwd:
       ssh_authorized_keys:
         - ssh-key foo
 ```
+
+```yaml
+# Butane config
+---
+variant: flatcar
+version: 1.0.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - ssh-key foo
+```
+
+Container Linux Configs are deprecated:
 
 ```yaml
 # Container Linux Config
@@ -97,7 +110,7 @@ Before `terraform-provider-ct` v0.10.0, Butane configs contained a `version` tha
 
 ### Binary
 
-To develop the provider plugin locally, build an executable with Go v1.16+.
+To develop the provider plugin locally, build an executable with Go v1.17+.
 
 ```
 make

--- a/ct/datasource_ct_config_flatcar_test.go
+++ b/ct/datasource_ct_config_flatcar_test.go
@@ -1,0 +1,190 @@
+package ct
+
+import (
+	"testing"
+
+	r "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const flatcarResource = `
+data "ct_config" "flatcar" {
+  pretty_print = true
+  strict = true
+  content = <<EOT
+---
+variant: flatcar
+version: 1.0.0
+storage:
+  luks:
+    - name: data
+      device: /dev/vdb
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - key
+EOT
+}
+`
+
+const flatcarExpected = `{
+  "ignition": {
+    "config": {
+      "replace": {
+        "verification": {}
+      }
+    },
+    "proxy": {},
+    "security": {
+      "tls": {}
+    },
+    "timeouts": {},
+    "version": "3.3.0"
+  },
+  "kernelArguments": {},
+  "passwd": {
+    "users": [
+      {
+        "name": "core",
+        "sshAuthorizedKeys": [
+          "key"
+        ]
+      }
+    ]
+  },
+  "storage": {
+    "luks": [
+      {
+        "clevis": {
+          "custom": {}
+        },
+        "device": "/dev/vdb",
+        "keyFile": {
+          "verification": {}
+        },
+        "name": "data"
+      }
+    ]
+  },
+  "systemd": {}
+}`
+
+const flatcarWithSnippets = `
+data "ct_config" "flatcar-snippets" {
+  pretty_print = true
+  strict = true
+  content = <<EOT
+---
+variant: flatcar
+version: 1.0.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - key
+EOT
+	snippets = [
+<<EOT
+---
+variant: flatcar
+version: 1.0.0
+systemd:
+  units:
+    - name: docker.service
+      enabled: true
+EOT
+	]
+}
+`
+
+const flatcarWithSnippetsExpected = `{
+  "ignition": {
+    "config": {
+      "replace": {
+        "verification": {}
+      }
+    },
+    "proxy": {},
+    "security": {
+      "tls": {}
+    },
+    "timeouts": {},
+    "version": "3.3.0"
+  },
+  "kernelArguments": {},
+  "passwd": {
+    "users": [
+      {
+        "name": "core",
+        "sshAuthorizedKeys": [
+          "key"
+        ]
+      }
+    ]
+  },
+  "storage": {},
+  "systemd": {
+    "units": [
+      {
+        "enabled": true,
+        "name": "docker.service"
+      }
+    ]
+  }
+}`
+
+const flatcarWithSnippetsPrettyFalse = `
+data "ct_config" "flatcar-snippets" {
+  pretty_print = false
+  strict = true
+  content = <<EOT
+---
+variant: flatcar
+version: 1.0.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - key
+EOT
+	snippets = [
+<<EOT
+---
+variant: flatcar
+version: 1.0.0
+systemd:
+  units:
+    - name: docker.service
+      enabled: true
+EOT
+	]
+}
+`
+
+const flatcarWithSnippetsPrettyFalseExpected = `{"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{},"version":"3.3.0"},"kernelArguments":{},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["key"]}]},"storage":{},"systemd":{"units":[{"enabled":true,"name":"docker.service"}]}}`
+
+func TestFlatcarButaneConfig(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		Providers: testProviders,
+		Steps: []r.TestStep{
+			{
+				Config: flatcarResource,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.flatcar", "rendered", flatcarExpected),
+				),
+			},
+			{
+				Config: flatcarWithSnippets,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.flatcar-snippets", "rendered", flatcarWithSnippetsExpected),
+				),
+			},
+			{
+				Config: flatcarWithSnippetsPrettyFalse,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.flatcar-snippets", "rendered", flatcarWithSnippetsPrettyFalseExpected),
+				),
+			},
+		},
+	})
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,13 +13,13 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.10.0"
+      version = "0.11.0"
     }
   }
 }
 ```
 
-Define a Butane config (for Fedora CoreOS) or Container Linux Config (for Flatcar Linux):
+Define a Butane config for Fedora CoreOS or Flatcar Linux:
 
 ```yaml
 # Butane config
@@ -32,6 +32,20 @@ passwd:
       ssh_authorized_keys:
         - ssh-key foo
 ```
+
+```yaml
+# Butane config
+---
+variant: flatcar
+version: 1.0.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - ssh-key foo
+```
+
+Container Linux Configs are deprecated:
 
 ```yaml
 # Container Linux Config

--- a/go.mod
+++ b/go.mod
@@ -1,16 +1,75 @@
 module github.com/poseidon/terraform-provider-ct
 
 require (
-	github.com/ajeddeloh/go-json v0.0.0-20170920214419-6a2fe990e083 // indirect
-	github.com/ajeddeloh/yaml v0.0.0-20170912190910-6b94386aeefd // indirect
-	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/coreos/butane v0.15.0
 	github.com/coreos/container-linux-config-transpiler v0.9.1-0.20200402130652-e4d5be564a0b
 	github.com/coreos/ignition v0.35.0
 	github.com/coreos/ignition/v2 v2.14.0
 	github.com/hashicorp/terraform-plugin-sdk v1.17.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.20.0
-	go4.org v0.0.0-20200312051459-7028f7b4a332 // indirect
 )
 
-go 1.16
+require (
+	github.com/agext/levenshtein v1.2.2 // indirect
+	github.com/ajeddeloh/go-json v0.0.0-20170920214419-6a2fe990e083 // indirect
+	github.com/ajeddeloh/yaml v0.0.0-20170912190910-6b94386aeefd // indirect
+	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/aws/aws-sdk-go v1.37.0 // indirect
+	github.com/clarketm/json v1.14.1 // indirect
+	github.com/coreos/go-json v0.0.0-20211020211907-c63f628265de // indirect
+	github.com/coreos/go-semver v0.3.0 // indirect
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e // indirect
+	github.com/coreos/go-systemd/v22 v22.0.0 // indirect
+	github.com/coreos/vcontext v0.0.0-20220603180515-2076d8d16945 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fatih/color v1.13.0 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.8 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-plugin v1.4.4 // indirect
+	github.com/hashicorp/go-uuid v1.0.3 // indirect
+	github.com/hashicorp/go-version v1.6.0 // indirect
+	github.com/hashicorp/hc-install v0.4.0 // indirect
+	github.com/hashicorp/hcl/v2 v2.13.0 // indirect
+	github.com/hashicorp/logutils v1.0.0 // indirect
+	github.com/hashicorp/terraform-exec v0.17.2 // indirect
+	github.com/hashicorp/terraform-json v0.14.0 // indirect
+	github.com/hashicorp/terraform-plugin-go v0.12.0 // indirect
+	github.com/hashicorp/terraform-plugin-log v0.7.0 // indirect
+	github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c // indirect
+	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
+	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/oklog/run v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.7.2 // indirect
+	github.com/vincent-petithory/dataurl v1.0.0 // indirect
+	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
+	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
+	github.com/vmihailenco/tagparser v0.1.1 // indirect
+	github.com/zclconf/go-cty v1.10.0 // indirect
+	go4.org v0.0.0-20200312051459-7028f7b4a332 // indirect
+	golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167 // indirect
+	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
+	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d // indirect
+	google.golang.org/grpc v1.48.0 // indirect
+	google.golang.org/protobuf v1.28.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+go 1.17


### PR DESCRIPTION
* Add tests for Butane Config flatcar variant
* Update README and docs for v0.11.0 release
* Update minimum Go version to v1.17
* Deprecate Container Linux Config, these can be written as Butane Configs with the new flatcar variant

```tf
variant: flatcar
version: 1.0.0
passwd:
  users:
    - name: core
      ssh_authorized_keys:
        - ssh-key foo
```