### PR TITLE
docs: Remove last references to CLC

### DIFF
--- a/docs/data-sources/ct_config.md
+++ b/docs/data-sources/ct_config.md
@@ -1,6 +1,6 @@
 # ct_config Data Source
 
-Validate a [Container Linux Config](https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/configuration.md) or a [Butane config](https://coreos.github.io/butane/specs/) and transpile it to an [Ignition config](https://coreos.github.io/ignition/) for machine consumption.
+Validate a [Butane config](https://coreos.github.io/butane/specs/) and transpile it to an [Ignition config](https://coreos.github.io/ignition/) for machine consumption.
 
 ## Usage
 
@@ -21,15 +21,14 @@ resource "aws_instance" "worker" {
 }
 ```
 
-See the [Container Linux](examples/container-linux.tf) or [Fedora CoreOS](examples/fedora-coreos.tf) examples.
+See the [Flatcar Container Linux](examples/flatcar-linux.tf) or [Fedora CoreOS](examples/fedora-coreos.tf) examples.
 
 ## Argument Reference
 
-* `content` - contents of a Container Linux Config (CLC) or Fedora CoreOS Config (FCC) that should be validated and transpiled to Ignition.
+* `content` - contents of a Butane Config that should be validated and transpiled to Ignition.
 * `strict` - strictly treat validation warnings as errors (default: false).
 * `pretty_print` - indent transpiled Ignition for visual prettiness (default: false)
-* `snippets` - list of Container Linux Config (CLC) or Fedora CoreOS Config (FCC) snippets to merge into the content. For FCCs, content and snippet configs must have the same `version`.
-* `platform` - (Container Linux only) - enable [platform-specific](https://github.com/coreos/container-linux-config-transpiler/blob/master/config/platform/platform.go) susbstitutions
+* `snippets` - list of Butane snippets to merge into the content. Content and snippet configs must have the same `version` and `variant`.
 
 ## Argument Attributes
 


### PR DESCRIPTION
The transpilation is now done for Butane only.
Also fix a broken link.
