### PR TITLE
thread files_dir through to butane

### DIFF
--- a/ct/datasource_ct_config.go
+++ b/ct/datasource_ct_config.go
@@ -52,6 +52,11 @@ func dataSourceCTConfig() *schema.Resource {
 				Computed:    true,
 				Description: "rendered ignition configuration",
 			},
+			"files_dir": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "directory to store files in",
+			},
 		},
 	}
 }
@@ -78,6 +83,7 @@ func renderConfig(d *schema.ResourceData) (string, error) {
 	pretty := d.Get("pretty_print").(bool)
 	strict := d.Get("strict").(bool)
 	snippetsIface := d.Get("snippets").([]interface{})
+	filesDir := d.Get("files_dir").(string)
 
 	snippets := make([]string, len(snippetsIface))
 	for i, v := range snippetsIface {
@@ -87,14 +93,17 @@ func renderConfig(d *schema.ResourceData) (string, error) {
 	}
 
 	// Butane Config
-	ign, err := butaneToIgnition([]byte(content), pretty, strict, snippets)
+	ign, err := butaneToIgnition([]byte(content), pretty, strict, snippets, filesDir)
 	return string(ign), err
 }
 
 // Translate Fedora CoreOS config to Ignition v3.X.Y
-func butaneToIgnition(data []byte, pretty, strict bool, snippets []string) ([]byte, error) {
+func butaneToIgnition(data []byte, pretty, strict bool, snippets []string, filesDir string) ([]byte, error) {
 	ignBytes, report, err := butane.TranslateBytes(data, common.TranslateBytesOptions{
 		Pretty: pretty,
+		TranslateOptions: common.TranslateOptions{
+			FilesDir: filesDir,
+		},
 	})
 	// ErrNoVariant indicates data is a CLC, not an FCC
 	if err != nil {


### PR DESCRIPTION
Hi! Thanks for this library :)

I decided to pull some file definitions out of my main file and notices this provider doesn't support the `-d` flag in butane. This changes that.

This does not cause caching issues, since the butane file is evaluated every time.