### PR TITLE
Release poseidon/ct v0.12.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,12 +4,14 @@ Notable changes between releases.
 
 ## Latest
 
+## v0.12.0
+
 * Remove support for Container Linux Configs ([#132](https://github.com/poseidon/terraform-provider-ct/pull/132))
   * Butane Configs support `fcos` and `flatcar` variants
+  * Focus on converting Butane Configs (with different variants) to Ignition
   * Flatcar Linux now supports Ignition v3.3.0
-  * Focus on converting Butane Configsi (with different variants) to Ignition
-* Remove unused github.com/coroes/ignition (v1) dependencies
-* Deprecate the `platform` field, its no longer used
+* Remove unused `github.com/coroes/ignition` (v1) dependencies
+* Deprecate the `platform` field, it's no longer used
 
 ## v0.11.0
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.11.0"
+      version = "0.12.0"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.11.0"
+      version = "0.12.0"
     }
   }
 }

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -5,7 +5,7 @@ terraform {
     local = "~> 1.2"
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.11.0"
+      version = "~> 0.12.0"
       #source  = "terraform.localhost/poseidon/ct"
       #version = "0.12.0"
     }


### PR DESCRIPTION
* Release v0.12.0 converts Butane Configs to Ignition spec v3.3.0 (via forward compatibility)