### PR TITLE
Update the target stable Ignition spec version to v3.4.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Notable changes between releases.
 
 ## Latest
 
+* Update the target stable Ignition spec version to v3.4.0 ([#156](https://github.com/poseidon/terraform-provider-ct/pull/156))
+  * Parse Butane Configs to Ignition v3.4.0
+
 ## v0.12.0
 
 * Remove support for Container Linux Configs ([#132](https://github.com/poseidon/terraform-provider-ct/pull/132))

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,7 @@ SEMVER=$(shell git describe --tags --match=v* --always --dirty | cut -c 2-)
 all: build test vet fmt
 
 .PHONY: build
-build: clean bin/terraform-provider-ct
-
-bin/terraform-provider-ct:
+build:
 	@go build -o $@ github.com/poseidon/terraform-provider-ct
 
 .PHONY: test
@@ -23,6 +21,10 @@ vet:
 .PHONY: fmt
 fmt:
 	@test -z $$(go fmt ./...)
+
+.PHONY: lint
+lint:
+	@golangci-lint run ./...
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -92,10 +92,12 @@ $ terraform init
 
 ## Versions
 
-Butane configs are converted to the current (according to this provider) stable Ignition config and merged together. For example, a Butane Config with `version: 1.2.0` would produce an Ignition config with version `v3.3.0`. This relies on Ignition's [forward compatibility](https://github.com/coreos/ignition/blob/main/config/v3_3/config.go#L61).
+Butane configs are converted to the current (according to this provider) stable Ignition config and merged together. For example, `poseidon/ct` `v0.12.0` would convert a Butane Config with `variant: fcos` and `version: 1.2.0` to an Ignition config with version `v3.3.0`. This relies on Ignition's [forward compatibility](https://github.com/coreos/ignition/blob/main/config/v3_3/config.go#L61).
 
-| terraform-provider-ct | Butane variant | Butane version | Ignition verison |
+| poseidon/ct           | Butane variant | Butane version | Ignition verison |
 |-----------------------|----------------|----------------|------------------|
+| 0.13.x                | fcos    | 1.0.0, 1.1.0, 1.2.0, 1.3.0, 1.4.0, 1.5.0 | 3.4.0 |
+| 0.13.x                | flatcar | 1.0.0, 1.1.0                      | 3.4.0 |
 | 0.12.x                | fcos    | 1.0.0, 1.1.0, 1.2.0, 1.3.0, 1.4.0 | 3.3.0 |
 | 0.12.x                | flatcar | 1.0.0                             | 3.3.0 |
 

--- a/ct/datasource_ct_config.go
+++ b/ct/datasource_ct_config.go
@@ -10,7 +10,7 @@ import (
 
 	butane "github.com/coreos/butane/config"
 	"github.com/coreos/butane/config/common"
-	ignition33 "github.com/coreos/ignition/v2/config/v3_3"
+	ignition "github.com/coreos/ignition/v2/config/v3_4"
 )
 
 func dataSourceCTConfig() *schema.Resource {
@@ -110,7 +110,7 @@ func butaneToIgnition(data []byte, pretty, strict bool, snippets []string) ([]by
 
 // Parse Fedora CoreOS Ignition and Butane snippets into Ignition Config.
 func mergeFCCSnippets(ignBytes []byte, pretty, strict bool, snippets []string) ([]byte, error) {
-	ign, _, err := ignition33.ParseCompatibleVersion(ignBytes)
+	ign, _, err := ignition.ParseCompatibleVersion(ignBytes)
 	if err != nil {
 		return nil, fmt.Errorf("%v", err)
 	}
@@ -130,11 +130,11 @@ func mergeFCCSnippets(ignBytes []byte, pretty, strict bool, snippets []string) (
 			return nil, fmt.Errorf("strict parsing error: %v", report.String())
 		}
 
-		ignext, _, err := ignition33.ParseCompatibleVersion(ignextBytes)
+		ignext, _, err := ignition.ParseCompatibleVersion(ignextBytes)
 		if err != nil {
 			return nil, fmt.Errorf("snippet parse error: %v, expect v1.4.0", err)
 		}
-		ign = ignition33.Merge(ign, ignext)
+		ign = ignition.Merge(ign, ignext)
 	}
 
 	return marshalJSON(ign, pretty)

--- a/ct/datasource_ct_config_flatcar_test.go
+++ b/ct/datasource_ct_config_flatcar_test.go
@@ -6,7 +6,114 @@ import (
 	r "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-const flatcarResource = `
+// Flatcar variant, v1.1.0
+
+const flatcarV11Resource = `
+data "ct_config" "flatcar" {
+  pretty_print = true
+  strict = true
+  content = <<EOT
+---
+variant: flatcar
+version: 1.1.0
+storage:
+  luks:
+    - name: data
+      device: /dev/vdb
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - key
+EOT
+}
+`
+
+const flatcarV11WithSnippets = `
+data "ct_config" "flatcar-snippets" {
+  pretty_print = true
+  strict = true
+  content = <<EOT
+---
+variant: flatcar
+version: 1.1.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - key
+EOT
+	snippets = [
+<<EOT
+---
+variant: flatcar
+version: 1.1.0
+systemd:
+  units:
+    - name: docker.service
+      enabled: true
+EOT
+	]
+}
+`
+
+const flatcarV11WithSnippetsPrettyFalse = `
+data "ct_config" "flatcar-snippets" {
+  pretty_print = false
+  strict = true
+  content = <<EOT
+---
+variant: flatcar
+version: 1.1.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - key
+EOT
+	snippets = [
+<<EOT
+---
+variant: flatcar
+version: 1.1.0
+systemd:
+  units:
+    - name: docker.service
+      enabled: true
+EOT
+	]
+}
+`
+
+func TestButaneConfig_Flatcar_v1_1(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		Providers: testProviders,
+		Steps: []r.TestStep{
+			{
+				Config: flatcarV11Resource,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.flatcar", "rendered", flatcarExpected),
+				),
+			},
+			{
+				Config: flatcarV11WithSnippets,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.flatcar-snippets", "rendered", flatcarWithSnippetsExpected),
+				),
+			},
+			{
+				Config: flatcarV11WithSnippetsPrettyFalse,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.flatcar-snippets", "rendered", flatcarWithSnippetsPrettyFalseExpected),
+				),
+			},
+		},
+	})
+}
+
+// Flatcar variant, v1.0.0
+
+const flatcarV10Resource = `
 data "ct_config" "flatcar" {
   pretty_print = true
   strict = true
@@ -39,7 +146,7 @@ const flatcarExpected = `{
       "tls": {}
     },
     "timeouts": {},
-    "version": "3.3.0"
+    "version": "3.4.0"
   },
   "kernelArguments": {},
   "passwd": {
@@ -69,7 +176,7 @@ const flatcarExpected = `{
   "systemd": {}
 }`
 
-const flatcarWithSnippets = `
+const flatcarV10WithSnippets = `
 data "ct_config" "flatcar-snippets" {
   pretty_print = true
   strict = true
@@ -109,7 +216,7 @@ const flatcarWithSnippetsExpected = `{
       "tls": {}
     },
     "timeouts": {},
-    "version": "3.3.0"
+    "version": "3.4.0"
   },
   "kernelArguments": {},
   "passwd": {
@@ -133,7 +240,7 @@ const flatcarWithSnippetsExpected = `{
   }
 }`
 
-const flatcarWithSnippetsPrettyFalse = `
+const flatcarV10WithSnippetsPrettyFalse = `
 data "ct_config" "flatcar-snippets" {
   pretty_print = false
   strict = true
@@ -161,26 +268,26 @@ EOT
 }
 `
 
-const flatcarWithSnippetsPrettyFalseExpected = `{"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{},"version":"3.3.0"},"kernelArguments":{},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["key"]}]},"storage":{},"systemd":{"units":[{"enabled":true,"name":"docker.service"}]}}`
+const flatcarWithSnippetsPrettyFalseExpected = `{"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{},"version":"3.4.0"},"kernelArguments":{},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["key"]}]},"storage":{},"systemd":{"units":[{"enabled":true,"name":"docker.service"}]}}`
 
-func TestFlatcarButaneConfig(t *testing.T) {
+func TestButaneConfig_Flatcar_v1_0(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
 		Steps: []r.TestStep{
 			{
-				Config: flatcarResource,
+				Config: flatcarV10Resource,
 				Check: r.ComposeTestCheckFunc(
 					r.TestCheckResourceAttr("data.ct_config.flatcar", "rendered", flatcarExpected),
 				),
 			},
 			{
-				Config: flatcarWithSnippets,
+				Config: flatcarV10WithSnippets,
 				Check: r.ComposeTestCheckFunc(
 					r.TestCheckResourceAttr("data.ct_config.flatcar-snippets", "rendered", flatcarWithSnippetsExpected),
 				),
 			},
 			{
-				Config: flatcarWithSnippetsPrettyFalse,
+				Config: flatcarV10WithSnippetsPrettyFalse,
 				Check: r.ComposeTestCheckFunc(
 					r.TestCheckResourceAttr("data.ct_config.flatcar-snippets", "rendered", flatcarWithSnippetsPrettyFalseExpected),
 				),

--- a/ct/datasource_ct_config_test.go
+++ b/ct/datasource_ct_config_test.go
@@ -12,7 +12,112 @@ var testProviders = map[string]*schema.Provider{
 	"ct": Provider(),
 }
 
-// Fedora CoreOS
+// Fedora CoreOS variant, v1.5.0
+
+const fedoraCoreOSV15Resource = `
+data "ct_config" "fedora-coreos" {
+  pretty_print = true
+  strict = true
+  content = <<EOT
+---
+variant: fcos
+version: 1.5.0
+storage:
+  luks:
+    - name: data
+      device: /dev/vdb
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - key
+EOT
+}
+`
+
+const fedoraCoreOSV15WithSnippets = `
+data "ct_config" "fedora-coreos-snippets" {
+  pretty_print = true
+  strict = true
+  content = <<EOT
+---
+variant: fcos
+version: 1.5.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - key
+EOT
+	snippets = [
+<<EOT
+---
+variant: fcos
+version: 1.5.0
+systemd:
+  units:
+    - name: docker.service
+      enabled: true
+EOT
+	]
+}
+`
+
+const fedoraCoreOSV15WithSnippetsPrettyFalse = `
+data "ct_config" "fedora-coreos-snippets" {
+  pretty_print = false
+  strict = true
+  content = <<EOT
+---
+variant: fcos
+version: 1.5.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - key
+EOT
+	snippets = [
+<<EOT
+---
+variant: fcos
+version: 1.5.0
+systemd:
+  units:
+    - name: docker.service
+      enabled: true
+EOT
+	]
+}
+`
+
+func TestButaneConfig_FCOSv1_5(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		Providers: testProviders,
+		Steps: []r.TestStep{
+			{
+				Config: fedoraCoreOSV15Resource,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos", "rendered", ignitionV34Expected),
+				),
+			},
+			{
+				Config: fedoraCoreOSV15WithSnippets,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV34WithSnippetsExpected),
+				),
+			},
+			{
+				Config: fedoraCoreOSV15WithSnippetsPrettyFalse,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV34WithSnippetsPrettyFalseExpected),
+				),
+			},
+		},
+	})
+}
+
+// Fedora CoreOS variant, v1.4.0
 
 const fedoraCoreOSV14Resource = `
 data "ct_config" "fedora-coreos" {
@@ -35,7 +140,7 @@ EOT
 }
 `
 
-const ignitionV33Expected = `{
+const ignitionV34Expected = `{
   "ignition": {
     "config": {
       "replace": {
@@ -47,7 +152,7 @@ const ignitionV33Expected = `{
       "tls": {}
     },
     "timeouts": {},
-    "version": "3.3.0"
+    "version": "3.4.0"
   },
   "kernelArguments": {},
   "passwd": {
@@ -105,7 +210,7 @@ EOT
 }
 `
 
-const ignitionV33WithSnippetsExpected = `{
+const ignitionV34WithSnippetsExpected = `{
   "ignition": {
     "config": {
       "replace": {
@@ -117,7 +222,7 @@ const ignitionV33WithSnippetsExpected = `{
       "tls": {}
     },
     "timeouts": {},
-    "version": "3.3.0"
+    "version": "3.4.0"
   },
   "kernelArguments": {},
   "passwd": {
@@ -169,33 +274,35 @@ EOT
 }
 `
 
-const ignitionV33WithSnippetsPrettyFalseExpected = `{"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{},"version":"3.3.0"},"kernelArguments":{},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["key"]}]},"storage":{},"systemd":{"units":[{"enabled":true,"name":"docker.service"}]}}`
+const ignitionV34WithSnippetsPrettyFalseExpected = `{"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{},"version":"3.4.0"},"kernelArguments":{},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["key"]}]},"storage":{},"systemd":{"units":[{"enabled":true,"name":"docker.service"}]}}`
 
-func TestButaneConfigV14(t *testing.T) {
+func TestButaneConfig_FCOSv1_4(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
 		Steps: []r.TestStep{
 			{
 				Config: fedoraCoreOSV14Resource,
 				Check: r.ComposeTestCheckFunc(
-					r.TestCheckResourceAttr("data.ct_config.fedora-coreos", "rendered", ignitionV33Expected),
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos", "rendered", ignitionV34Expected),
 				),
 			},
 			{
 				Config: fedoraCoreOSV14WithSnippets,
 				Check: r.ComposeTestCheckFunc(
-					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV33WithSnippetsExpected),
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV34WithSnippetsExpected),
 				),
 			},
 			{
 				Config: fedoraCoreOSV14WithSnippetsPrettyFalse,
 				Check: r.ComposeTestCheckFunc(
-					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV33WithSnippetsPrettyFalseExpected),
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV34WithSnippetsPrettyFalseExpected),
 				),
 			},
 		},
 	})
 }
+
+// Fedora CoreOS variant, v1.3.0
 
 const fedoraCoreOSV13Resource = `
 data "ct_config" "fedora-coreos" {
@@ -274,31 +381,33 @@ EOT
 }
 `
 
-func TestButaneConfigV13(t *testing.T) {
+func TestButaneConfig_FCOSv1_3(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
 		Steps: []r.TestStep{
 			{
 				Config: fedoraCoreOSV13Resource,
 				Check: r.ComposeTestCheckFunc(
-					r.TestCheckResourceAttr("data.ct_config.fedora-coreos", "rendered", ignitionV33Expected),
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos", "rendered", ignitionV34Expected),
 				),
 			},
 			{
 				Config: fedoraCoreOSV13WithSnippets,
 				Check: r.ComposeTestCheckFunc(
-					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV33WithSnippetsExpected),
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV34WithSnippetsExpected),
 				),
 			},
 			{
 				Config: fedoraCoreOSV13WithSnippetsPrettyFalse,
 				Check: r.ComposeTestCheckFunc(
-					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV33WithSnippetsPrettyFalseExpected),
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV34WithSnippetsPrettyFalseExpected),
 				),
 			},
 		},
 	})
 }
+
+// Fedora CoreOS variant, v1.2.0
 
 const fedoraCoreOSV12Resource = `
 data "ct_config" "fedora-coreos" {
@@ -377,31 +486,33 @@ EOT
 }
 `
 
-func TestButaneConfigV12(t *testing.T) {
+func TestButaneConfig_FCOSv1_2(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
 		Steps: []r.TestStep{
 			{
 				Config: fedoraCoreOSV12Resource,
 				Check: r.ComposeTestCheckFunc(
-					r.TestCheckResourceAttr("data.ct_config.fedora-coreos", "rendered", ignitionV33Expected),
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos", "rendered", ignitionV34Expected),
 				),
 			},
 			{
 				Config: fedoraCoreOSV12WithSnippets,
 				Check: r.ComposeTestCheckFunc(
-					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV33WithSnippetsExpected),
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV34WithSnippetsExpected),
 				),
 			},
 			{
 				Config: fedoraCoreOSV12WithSnippetsPrettyFalse,
 				Check: r.ComposeTestCheckFunc(
-					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV33WithSnippetsPrettyFalseExpected),
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV34WithSnippetsPrettyFalseExpected),
 				),
 			},
 		},
 	})
 }
+
+// Fedora CoreOS variant, v1.1.0
 
 const fedoraCoreOSV11Resource = `
 data "ct_config" "fedora-coreos" {
@@ -421,7 +532,7 @@ EOT
 `
 
 // Butane v1.2 added storage.luks, which we exercise
-const ignitionV33BeforeButaneV12 = `{
+const ignitionV34BeforeButaneV12 = `{
   "ignition": {
     "config": {
       "replace": {
@@ -433,7 +544,7 @@ const ignitionV33BeforeButaneV12 = `{
       "tls": {}
     },
     "timeouts": {},
-    "version": "3.3.0"
+    "version": "3.4.0"
   },
   "kernelArguments": {},
   "passwd": {
@@ -506,31 +617,33 @@ EOT
 }
 `
 
-func TestButaneConfigV11(t *testing.T) {
+func TestButaneConfig_FCOSv1_1(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
 		Steps: []r.TestStep{
 			{
 				Config: fedoraCoreOSV11Resource,
 				Check: r.ComposeTestCheckFunc(
-					r.TestCheckResourceAttr("data.ct_config.fedora-coreos", "rendered", ignitionV33BeforeButaneV12),
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos", "rendered", ignitionV34BeforeButaneV12),
 				),
 			},
 			{
 				Config: fedoraCoreOSV11WithSnippets,
 				Check: r.ComposeTestCheckFunc(
-					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV33WithSnippetsExpected),
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV34WithSnippetsExpected),
 				),
 			},
 			{
 				Config: fedoraCoreOSV11WithSnippetsPrettyFalse,
 				Check: r.ComposeTestCheckFunc(
-					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV33WithSnippetsPrettyFalseExpected),
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV34WithSnippetsPrettyFalseExpected),
 				),
 			},
 		},
 	})
 }
+
+// Fedora CoreOS variant, v1.0.0
 
 const fedoraCoreOSV10Resource = `
 data "ct_config" "fedora-coreos" {
@@ -605,26 +718,26 @@ EOT
 }
 `
 
-func TestButaneConfigV10(t *testing.T) {
+func TestButaneConfig_FCOSv1_0(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
 		Steps: []r.TestStep{
 			{
 				Config: fedoraCoreOSV10Resource,
 				Check: r.ComposeTestCheckFunc(
-					r.TestCheckResourceAttr("data.ct_config.fedora-coreos", "rendered", ignitionV33BeforeButaneV12),
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos", "rendered", ignitionV34BeforeButaneV12),
 				),
 			},
 			{
 				Config: fedoraCoreOSV10WithSnippets,
 				Check: r.ComposeTestCheckFunc(
-					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV33WithSnippetsExpected),
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV34WithSnippetsExpected),
 				),
 			},
 			{
 				Config: fedoraCoreOSV10WithSnippetsPrettyFalse,
 				Check: r.ComposeTestCheckFunc(
-					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV33WithSnippetsPrettyFalseExpected),
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-snippets", "rendered", ignitionV34WithSnippetsPrettyFalseExpected),
 				),
 			},
 		},
@@ -659,7 +772,7 @@ EOT
 }
 `
 
-const ignitionV33MixExpected = `{
+const ignitionV34MixExpected = `{
   "ignition": {
     "config": {
       "replace": {
@@ -671,7 +784,7 @@ const ignitionV33MixExpected = `{
       "tls": {}
     },
     "timeouts": {},
-    "version": "3.3.0"
+    "version": "3.4.0"
   },
   "kernelArguments": {},
   "passwd": {
@@ -702,7 +815,7 @@ func TestFedoraCoreOSMix_SnippetBehind(t *testing.T) {
 			{
 				Config: fedoraCoreOSMixSnippetBehind,
 				Check: r.ComposeTestCheckFunc(
-					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-mix-versions", "rendered", ignitionV33MixExpected),
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-mix-versions", "rendered", ignitionV34MixExpected),
 				),
 			},
 		},
@@ -744,7 +857,7 @@ func TestFedoraCoreOSMixVersions_SnippetAhead(t *testing.T) {
 			{
 				Config: fedoraCoreOSMixSnippetAhead,
 				Check: r.ComposeTestCheckFunc(
-					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-mix-versions", "rendered", ignitionV33MixExpected),
+					r.TestCheckResourceAttr("data.ct_config.fedora-coreos-mix-versions", "rendered", ignitionV34MixExpected),
 				),
 			},
 		},


### PR DESCRIPTION
* Upstream Ignition has stabalized the v3.4.0 spec and can parse and merge earlier versions to v3.4.0 (Ignition forward compatibility)
* Convert fcos variant Butane Configs to Ignition v3.4.0 spec
* Convert flatcar variant Butane Configs to Ignition v3.4.0 spec