### PR TITLE
Remove deprecated platform field from ct_config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,11 @@ Notable changes between releases.
 
 ## Latest
 
+## v0.13.0
+
 * Update the target stable Ignition spec version to v3.4.0 ([#156](https://github.com/poseidon/terraform-provider-ct/pull/156))
-  * Parse Butane Configs to Ignition v3.4.0
+  * Parse Butane Configs to Ignition v3.4.0 ([#159](https://github.com/poseidon/terraform-provider-ct/pull/159))
+* Remove deprecated `platform` field
 * Move implementation to an `internal` package ([#157](https://github.com/poseidon/terraform-provider-ct/pull/157))
 
 ## v0.12.0

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.12.0"
+      version = "0.13.0"
     }
   }
 }
@@ -28,7 +28,7 @@ Define a Butane config for Fedora CoreOS or Flatcar Linux:
 
 ```yaml
 variant: fcos
-version: 1.4.0
+version: 1.5.0
 passwd:
   users:
     - name: core
@@ -38,7 +38,7 @@ passwd:
 
 ```yaml
 variant: flatcar
-version: 1.0.0
+version: 1.1.0
 passwd:
   users:
     - name: core

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -5,7 +5,7 @@ terraform {
     local = "~> 1.2"
     ct = {
       source  = "poseidon/ct"
-      version = "~> 0.12.0"
+      version = "~> 0.13.0"
       #source  = "terraform.localhost/poseidon/ct"
       #version = "0.12.0"
     }

--- a/internal/data_config.go
+++ b/internal/data_config.go
@@ -22,13 +22,6 @@ func DatasourceConfig() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"platform": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Default:    "",
-				Deprecated: "platform is no longer used",
-				ForceNew:   true,
-			},
 			"snippets": {
 				Type: schema.TypeList,
 				Elem: &schema.Schema{


### PR DESCRIPTION
* Remove the `platform` field, which was deprecated in v0.12.0