### PR TITLE
feat: Add support to include files in configs

### DIFF
--- a/examples/content/fcos.yaml
+++ b/examples/content/fcos.yaml
@@ -12,6 +12,10 @@ storage:
       contents:
         inline: |
           ${message}
+    - path: /etc/foo
+      contents:
+        local: foo.txt
+
 passwd:
   users:
     - name: core

--- a/examples/content/foo.txt
+++ b/examples/content/foo.txt
@@ -1,0 +1,1 @@
+some content

--- a/examples/fedora-coreos.tf
+++ b/examples/fedora-coreos.tf
@@ -5,6 +5,7 @@ data "ct_config" "fedora-coreos-config" {
   })
   strict       = true
   pretty_print = true
+  files_dir    = "${path.module}/content"
 
   snippets = [
     file("${path.module}/content/fcos-snippet.yaml"),

--- a/internal/data_config_fcos_test.go
+++ b/internal/data_config_fcos_test.go
@@ -878,3 +878,68 @@ func TestInvalidResource(t *testing.T) {
 		},
 	})
 }
+
+const fileInclude = `
+data "ct_config" "file-include" {
+  content = <<-EOT
+---
+variant: fcos
+version: 1.5.0
+storage:
+  files:
+    - path: /etc/foo
+      contents:
+        local: foo.txt
+EOT
+  strict = true
+  pretty_print = true
+  files_dir = "../examples/content"
+}
+`
+const ignitionFileIncludeExpected = `{
+  "ignition": {
+    "config": {
+      "replace": {
+        "verification": {}
+      }
+    },
+    "proxy": {},
+    "security": {
+      "tls": {}
+    },
+    "timeouts": {},
+    "version": "3.4.0"
+  },
+  "kernelArguments": {},
+  "passwd": {},
+  "storage": {
+    "files": [
+      {
+        "group": {},
+        "path": "/etc/foo",
+        "user": {},
+        "contents": {
+          "compression": "",
+          "source": "data:,some%20content%0A",
+          "verification": {}
+        }
+      }
+    ]
+  },
+  "systemd": {}
+}`
+
+func TestFileInclude(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		Providers: testProviders,
+		Steps: []r.TestStep{
+			{
+				Config: fileInclude,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.file-include", "files_dir", "../examples/content"),
+					r.TestCheckResourceAttr("data.ct_config.file-include", "rendered", ignitionFileIncludeExpected),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
This commit implements support for Butane configs that include local files as file or systemd-unit contents:

    variant: fcos
    version: "1.5.0"
    storage:
      files:
        - path: /some/path
          contents:
            local: ./some.file
    systemd:
      units:
        - name: some.service
          contents_local: ./some-unit.service

Since files are included relative to the directory specified by the `FilesDir` argument, this only works if said argument is set.

As it stands today, Butane configs as outlined above will throw an error message.