### PR TITLE
Improve Makefile for local release testing

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,12 @@
+changelog:
+  categories:
+    - title: Contributions
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+          - no-release-note
+    - title: Dependencies
+      labels:
+        - dependencies


### PR DESCRIPTION
* Configure the release target to copy the release binary to the appropriate local location to test it without publishing