### PR TITLE
Add butane translate report to error message

### DIFF
--- a/internal/data_config.go
+++ b/internal/data_config.go
@@ -117,7 +117,7 @@ func mergeFCCSnippets(ignBytes []byte, pretty, strict bool, snippets []string) (
 			if err == common.ErrNoVariant {
 				return nil, fmt.Errorf("Butane snippets require `variant`: %v", err)
 			}
-			return nil, fmt.Errorf("Butane translate error: %v", err)
+			return nil, fmt.Errorf("Butane translate error: %v\n%s", err, report.String())
 		}
 		if strict && len(report.Entries) > 0 {
 			return nil, fmt.Errorf("strict parsing error: %v", report.String())


### PR DESCRIPTION
Without the report, if there is an error during translation, there is no explanation of where and why the error occurred